### PR TITLE
Read local dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,17 +5,22 @@ const chalk = require('chalk');
 const pkg = require('./package');
 const utils = require('./utils');
 
+const ERROR = chalk.red('Error:');
+const OK = chalk.green('Downloaded:');
+
+function download(repo, logger) {
+    utils.downloadRepo(repo).then(files => {
+        files.forEach(file => logger.info(OK, file));
+    }).catch(err => logger.error(ERROR, err.message));
+}
+
 const cli = prog
     .version(pkg.version)
-    .argument('<query>', 'Specify the repository to fetch.')
+    .argument('[query]', 'Specify the repository to fetch.')
     .action((args, options, logger) => {
-        utils.download(args.query)
-            .then((files) => {
-                files.forEach((file) => {
-                    logger.info(chalk.green('Downloaded:'), file);
-                });
-            })
-            .catch((err) => logger.error(chalk.red('Error'), err.message));
+        if (args.query) {
+            return download(args.query, logger);
+        }
     });
 
 prog.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -7,10 +7,11 @@ const utils = require('./utils');
 
 const ERROR = chalk.red('Error:');
 const OK = chalk.green('Downloaded:');
+const FROM = chalk.gray('from');
 
 function download(repo, logger) {
     utils.downloadRepo(repo).then(files => {
-        files.forEach(file => logger.info(OK, file));
+        files.forEach(file => logger.info(OK, `${file} ${FROM} ${repo}`));
     }).catch(err => logger.error(ERROR, err.message));
 }
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ const cli = prog
         if (args.query) {
             return download(args.query, logger);
         }
+
+        utils.getLocalDependencies().then(deps => {
+            deps.forEach(repo => download(repo, logger));
+        }).catch(err => logger.error(ERROR, err));
     });
 
 prog.parse(process.argv);

--- a/utils/index.js
+++ b/utils/index.js
@@ -99,7 +99,7 @@ const fetchFiles = (repoName, files) => {
  *
  * @param {String} repoName - The repo name
  */
-const download = (repoName) => new Promise((resolve, reject) => {
+const downloadRepo = (repoName) => new Promise((resolve, reject) => {
     const parts = repoName.split('/');
     if (parts.length !== 2) {
         throw new Error('Invalid repository name. Format should be "<username>/<repository>"');
@@ -119,5 +119,5 @@ const download = (repoName) => new Promise((resolve, reject) => {
 });
 
 module.exports = {
-    download,
+    downloadRepo,
 };


### PR DESCRIPTION
There's a `@TODO` note in there for recursively reading remote repos' `dependencies` key, too.

**Notable Changes**

- Without any `query` parameter, `zel` will look for a `.zel` file in the current directory & download any repositories if a `dependencies` key defined.

- An error will be shown if `zel` was run without a `query` and without a `.zel` file present in the current directory.

    ```
    Error: A `.zel` file does not exist in this directory.
    ```

- `parseBase64ToJson` was modified for error handling; prints a readable error message

    ```
    Error: Unexpected token in ".zel" from vutran/editorconfig
    Error: Unexpected token in /Users/lukee/repos/oss/zel/.zel
    ```
- The `Downloaded:` message was slightly modified to include _where_ the file was downloaded from:

    ```
    Downloaded: .editorconfig from vutran/editorconfig
    Downloaded: .gitignore from vutran/gitignore
    ```

    > Colors make a difference

**Other Changes**

- Extracted core CLI action to a top-level helper function: `download`
- Renamed `utils.download` to `utils.downloadRepo`