### PR TITLE
add ability to recursively download dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,13 @@ const OK = chalk.green('Downloaded:');
 const FROM = chalk.gray('from');
 
 function download(repo, logger) {
-    utils.downloadRepo(repo).then((files) => {
-        files.forEach(file => logger.info(OK, `${file} ${FROM} ${repo}`));
+    utils.downloadRepo(repo).then(({ files, dependencies }) => {
+        if (files && files.length) {
+            files.forEach(file => logger.info(OK, `${file} ${FROM} ${repo}`));
+        }
+        if (dependencies && dependencies.length) {
+            dependencies.forEach(dep => logger.info(OK, `${dep} ${FROM} ${repo}`));
+        }
     }).catch(err => logger.error(ERROR, err.message));
 }
 


### PR DESCRIPTION
Quick and dirty way to recursively download dependencies.

To test, run: `zel [vutran/new](https://github.com/vutran/new)`