### PR TITLE
add a resolver and validate command

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ function initLocal(logger) {
                 logger.error(ERROR, 'No local dependencies defined. Please define a repository.');
                 return;
             }
-            deps.forEach(repo => init(repo, logger));
+            deps.forEach((repo) => init(repo, logger));
         })
-        .catch(err => logger.error(ERROR, err));
+        .catch((err) => logger.error(ERROR, err));
 }
 
 prog
@@ -61,7 +61,7 @@ prog
                 });
                 resolver.validate(options.failFast);
             })
-            .catch(err => logger.error(ERROR, err));
+            .catch((err) => logger.error(ERROR, err));
     });
 
 prog.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ prog
         return initLocal(logger);
     })
 
-    .command('validate', 'Validates the .zel file.')
+    .command('validate', 'Validates local .zel file.')
     .option('--failFast', 'Terminates on error/invalid repository.')
     .action((args, options, logger) => {
         getLocalDependencies()

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function initLocal(logger) {
             }
             deps.forEach(repo => init(repo, logger));
         })
-        .catch((err) => logger.error(ERROR, err));
+        .catch(err => logger.error(ERROR, err));
 }
 
 prog
@@ -60,7 +60,8 @@ prog
                     logger.error(ERROR, err);
                 });
                 resolver.validate(options.failFast);
-            });
+            })
+            .catch(err => logger.error(ERROR, err));
     });
 
 prog.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ const prog = require('caporal');
 const { version } = require('./package');
 const { downloadRepo } = require('./lib/repository');
 const { getLocalDependencies } = require('./lib/local');
-const { ERROR, DOWNLOADED, TITLE, SPACER } = require('./lib/constants');
+const { ERROR, DOWNLOADED, TITLE, SPACER, VALID, INVALID } = require('./lib/constants');
+const Resolver = require('./lib/resolver');
 
 function init(repo, logger) {
     downloadRepo(repo)
@@ -18,13 +19,20 @@ function init(repo, logger) {
 }
 
 function initLocal(logger) {
-    getLocalDependencies().then((deps) => {
-        deps.forEach((repo) => init(repo, logger));
-    }).catch((err) => logger.error(ERROR, err));
+    getLocalDependencies()
+        .then((deps) => {
+            if (!deps.length) {
+                logger.error(ERROR, 'No local dependencies defined. Please define a repository.');
+                return;
+            }
+            deps.forEach(repo => init(repo, logger));
+        })
+        .catch((err) => logger.error(ERROR, err));
 }
 
 prog
     .version(version)
+
     .argument('[query]', 'Specify the repository to fetch.')
     .action((args, options, logger) => {
         logger.info('\r'); // padding
@@ -34,6 +42,25 @@ prog
         }
 
         return initLocal(logger);
+    })
+
+    .command('validate', 'Validates the .zel file.')
+    .option('--failFast', 'Terminates on error/invalid repository.')
+    .action((args, options, logger) => {
+        getLocalDependencies()
+            .then((deps) => {
+                const resolver = new Resolver(deps);
+                resolver.on('valid', (repoName) => {
+                    logger.info(VALID, repoName);
+                });
+                resolver.on('invalid', (repoName) => {
+                    logger.error(INVALID, repoName);
+                });
+                resolver.on('error', (err) => {
+                    logger.error(ERROR, err);
+                });
+                resolver.validate(options.failFast);
+            });
     });
 
 prog.parse(process.argv);

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,6 +5,9 @@ module.exports = {
     ERROR: chalk.red('Error:'),
     DOWNLOADED: chalk.green('Downloaded:'),
     SPACER: Array(14).join(' '),
-    TITLE: chalk.cyan.underline
+    TITLE: chalk.cyan.underline,
+    FROM: chalk.gray('from'),
+    VALID: chalk.green('Valid:'),
+    INVALID: chalk.red('Invalid:'),
 };
 

--- a/lib/local.js
+++ b/lib/local.js
@@ -10,7 +10,7 @@ const { bufferToJSON, getConfig } = require('./utils');
 const getLocalDependencies = () => new Promise((resolve, reject) => {
     const dotfile = path.resolve(DOTFILE);
     getConfig(dotfile)
-        .then((data) => data.dependencies || [])
+        .then((data) => resolve(data.dependencies || []))
         .catch((err) => reject(err));
 });
 

--- a/lib/local.js
+++ b/lib/local.js
@@ -10,10 +10,7 @@ const { bufferToJSON, getConfig } = require('./utils');
 const getLocalDependencies = () => new Promise((resolve, reject) => {
     const dotfile = path.resolve(DOTFILE);
     getConfig(dotfile)
-        .then((data) => {
-            const deps = data.dependencies;
-            return deps ? resolve(deps) : reject('No local dependencies defined. Please define a repository.');
-        })
+        .then((data) => data.dependencies || [])
         .catch((err) => reject(err));
 });
 

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -61,6 +61,7 @@ const fetchFiles = (repoName, files) => {
 };
 
 module.exports = {
+    getZelFile,
     downloadRepo,
     fetchFiles,
 };

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -26,8 +26,6 @@ module.exports = class Resolver extends EventEmitter {
             }
         }
 
-        let cont = true;
-
         if (ff) {
             Promise.each(this.repositories, this.validateSingle)
                 .then((repoNames) => repoNames.forEach((repoName) => this.emit('valid', repoName)))

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,0 +1,58 @@
+const EventEmitter = require('events');
+const Promise = require('bluebird');
+const { getZelFile } = require('./repository');
+
+module.exports = class Resolver extends EventEmitter {
+    /**
+     * @param {Array<String>} - List of repositories
+     */
+    constructor(repositories) {
+        super();
+        this.repositories = repositories || [];
+        this.validateSingle = this.validateSingle.bind(this);
+    }
+
+    /**
+     * Validates the repositories
+     *
+     * @param {Boolean} failFast - Terminates if an error/invalid event occurs
+     */
+    validate(failFast) {
+        const ff = failFast || false;
+        if (!this.repositories.length) {
+            this.emit('error', 'No repositories specified.');
+            if (ff) {
+                return false;
+            }
+        }
+
+        let cont = true;
+
+        if (ff) {
+            Promise.each(this.repositories, this.validateSingle)
+                .then((repoNames) => repoNames.forEach((repoName) => this.emit('valid', repoName)))
+                .catch((repoName) => this.emit('invalid', repoName));
+            return;
+        }
+
+        this.repositories.forEach((repoName) => {
+            this.validateSingle(repoName)
+                .then((repoName) => this.emit('valid', repoName))
+                .catch((repoName) => this.emit('invalid', repoName));
+        });
+    }
+
+    /**
+     * Validates a single repository by fetching it's dotfile
+     *
+     * @param {String} repoName
+     * @return {Promise<String>} - Resolves or reject the repo name
+     */
+    validateSingle(repoName) {
+        return new Promise((resolve, reject) => {
+            getZelFile(repoName)
+                .then(() => resolve(repoName))
+                .catch(() => reject(repoName));
+        });
+    }
+}

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -43,7 +43,7 @@ module.exports = class Resolver extends EventEmitter {
     }
 
     /**
-     * Validates a single repository by fetching it's dotfile
+     * Validates a single repository by fetching its dotfile
      *
      * @param {String} repoName
      * @return {Promise<String>} - Resolves or reject the repo name

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Vu Tran <vu@vu-tran.com>",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.5.0",
     "caporal": "^0.3.0",
     "chalk": "^1.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,7 +86,7 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
-bluebird@^3.4.7:
+bluebird@^3.4.7, bluebird@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 


### PR DESCRIPTION
- Rename constants to match its label
- New `Resolver` class - validates a list of repositories (partially addresses #7)
- New command `zel validate` which validates a local `.zel` file
  - Flag: `--failFast` - terminate process on errors
- Adds bluebird (partially addresses #1, used on `Resolver`)