### PR TITLE
Construct URL from repo-parts within utils/sync

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -54,10 +54,8 @@ const fetchFiles = (repoName, files) => {
         throw `No files specified in ${repoName}.`;
     }
 
-    files.forEach((file) => {
-        // @TODO - parse tag or branch name from `dependencies`
-        sync(repoName, 'master', file);
-    });
+    // @TODO - parse tag or branch name from `dependencies`
+    files.forEach((file) => sync(repoName, 'master', file));
 
     return files;
 };

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -55,8 +55,8 @@ const fetchFiles = (repoName, files) => {
     }
 
     files.forEach((file) => {
-        const downloadUrl = `https://raw.githubusercontent.com/${repoName}/master/${file}`;
-        sync(downloadUrl, file);
+        // @TODO - parse tag or branch name from `dependencies`
+        sync(repoName, 'master', file);
     });
 
     return files;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,10 +76,12 @@ const get = (uri, options) => new Promise((resolve, reject) => {
 /**
  * Downloads the contents from the given `url` to the `file` path.
  *
- * @param {String} url
+ * @param {String} repo
+ * @param {String} branch
  * @param {String} file
  */
-const sync = (url, file) => {
+const sync = (repo, branch, file) => {
+    const url = `https://raw.githubusercontent.com/${repo}/${branch}/${file}`;
     const fileStream = fs.createWriteStream(file);
     https.get(url, (resp) => {
         resp.pipe(fileStream);


### PR DESCRIPTION
Constructs its own URL from repository segments. Sets foundation for (later) handling branch & tag name specifications.