### PR TITLE
Refactor Resolver class

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,11 +50,11 @@ prog
     .action((args, options, logger) => {
         getLocalDependencies()
             .then((deps) => {
-                new Resolver(deps)
+                new Resolver(options)
                     .on('valid', (repoName) => logger.info(VALID, repoName))
                     .on('invalid', (repoName) => logger.error(INVALID, repoName))
                     .on('error', (err) => logger.error(ERROR, err))
-                    .validate(options.failFast);
+                    .validate(deps);
             })
             .catch((err) => logger.error(ERROR, err));
     });

--- a/index.js
+++ b/index.js
@@ -50,17 +50,11 @@ prog
     .action((args, options, logger) => {
         getLocalDependencies()
             .then((deps) => {
-                const resolver = new Resolver(deps);
-                resolver.on('valid', (repoName) => {
-                    logger.info(VALID, repoName);
-                });
-                resolver.on('invalid', (repoName) => {
-                    logger.error(INVALID, repoName);
-                });
-                resolver.on('error', (err) => {
-                    logger.error(ERROR, err);
-                });
-                resolver.validate(options.failFast);
+                new Resolver(deps)
+                    .on('valid', (repoName) => logger.info(VALID, repoName))
+                    .on('invalid', (repoName) => logger.error(INVALID, repoName))
+                    .on('error', (err) => logger.error(ERROR, err))
+                    .validate(options.failFast);
             })
             .catch((err) => logger.error(ERROR, err));
     });

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -17,15 +17,14 @@ module.exports = class Resolver extends EventEmitter {
      * @param {Boolean} failFast - Terminates if an error/invalid event occurs
      */
     validate(failFast) {
-        const ff = failFast || false;
         if (!this.repositories.length) {
             this.emit('error', 'No repositories specified.');
-            if (ff) {
+            if (failFast) {
                 return false;
             }
         }
 
-        if (ff) {
+        if (failFast) {
             Promise.each(this.repositories, this.validateSingle)
                 .then((repoNames) => repoNames.forEach((repoName) => this.emit('valid', repoName)))
                 .catch((repoName) => this.emit('invalid', repoName));

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -8,7 +8,6 @@ module.exports = class Resolver extends EventEmitter {
     constructor(repositories) {
         super();
         this.repositories = repositories || [];
-        this.validateSingle = this.validateSingle.bind(this);
     }
 
     /**
@@ -32,23 +31,9 @@ module.exports = class Resolver extends EventEmitter {
         }
 
         this.repositories.forEach((repoName) => {
-            this.validateSingle(repoName)
-                .then((repoName) => this.emit('valid', repoName))
-                .catch((repoName) => this.emit('invalid', repoName));
-        });
-    }
-
-    /**
-     * Validates a single repository by fetching its dotfile
-     *
-     * @param {String} repoName
-     * @return {Promise<String>} - Resolves or reject the repo name
-     */
-    validateSingle(repoName) {
-        return new Promise((resolve, reject) => {
             getZelFile(repoName)
-                .then(() => resolve(repoName))
-                .catch(() => reject(repoName));
+                .then(() => this.emit('valid', repoName))
+                .catch(() => this.emit('invalid', repoName));
         });
     }
 };

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -3,20 +3,22 @@ const { getZelFile } = require('./repository');
 
 module.exports = class Resolver extends EventEmitter {
     /**
-     * @param {Array<String>} - List of repositories
+     * @param {Object<failFast>} failFast - Terminates if an error/invalid event occurs
      */
-    constructor(repositories) {
+    constructor(options) {
         super();
-        this.repositories = repositories || [];
+        this.opts = options || {};
     }
 
     /**
      * Validates the repositories
      *
-     * @param {Boolean} failFast - Terminates if an error/invalid event occurs
+     * @param {Array<String>} - List of repositories
      */
-    validate(failFast) {
-        if (!this.repositories.length) {
+    validate(repos) {
+        const failFast = this.opts.failFast;
+
+        if (!repos || !repos.length) {
             this.emit('error', 'No repositories specified.');
             if (failFast) {
                 return false;
@@ -24,16 +26,17 @@ module.exports = class Resolver extends EventEmitter {
         }
 
         if (failFast) {
-            Promise.each(this.repositories, this.validateSingle)
-                .then((repoNames) => repoNames.forEach((repoName) => this.emit('valid', repoName)))
+            const isValid = (name) => this.emit('valid', name);
+            Promise.each(repos, getZelFile)
+                .then((repoNames) => repoNames.forEach(isValid))
                 .catch((repoName) => this.emit('invalid', repoName));
             return;
         }
 
-        this.repositories.forEach((repoName) => {
-            getZelFile(repoName)
-                .then(() => this.emit('valid', repoName))
-                .catch(() => this.emit('invalid', repoName));
-        });
+        const check = (repoName) => getZelFile(repoName)
+            .then(() => this.emit('valid', repoName))
+            .catch(() => this.emit('invalid', repoName));
+
+        Promise.all(repos.map(check));
     }
 };


### PR DESCRIPTION
To me, it made more sense to instantiate the class with `options` first, then pass in a list of `repos` if/when it was time to `validate()`. 

This way, it opens the door for more flag options on the command, and a single, initialized class can be reused (useful for the recursive dependency lookup).

Removed the `validateSingle` helper because it didn't add anything additional to the `getZelFile` util. 

Lastly, using `Promise.all` for a concurrency speed boost, if `failFast` wasn't set.