### PR TITLE
remove failFast and resolve before download

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,16 +30,6 @@ function clone(deps, logger) {
             .catch((err) => logger.error(LOG.ERROR, err));
 }
 
-function init(repo, logger) {
-    clone([ repo ], logger);
-}
-
-function initLocal(logger) {
-    getLocalDependencies()
-        .then((deps) => clone(deps, logger))
-        .catch((err) => logger.error(LOG.ERROR, err));
-}
-
 prog
     .version(version)
 
@@ -48,10 +38,12 @@ prog
         logger.info('\r'); // padding
 
         if (args.query) {
-            return init(args.query, logger);
+            return clone([repo], logger);
         }
 
-        return initLocal(logger);
+        return getLocalDependencies()
+            .then((deps) => clone(deps, logger))
+            .catch((err) => logger.error(LOG.ERROR, err));
     })
 
     .command('validate', 'Validates local .zel file.')

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ prog
         logger.info('\r'); // padding
 
         if (args.query) {
-            return clone([repo], logger);
+            return clone([args.query], logger);
         }
 
         return getLocalDependencies()
@@ -54,8 +54,7 @@ prog
                     .on('valid', (repo) => logger.info(LOG.VALID, repo.repoName))
                     .on('invalid', (repo) => logger.error(LOG.INVALID, repo.repoName))
                     .validate(deps)
-                        .catch(err => logger.error(LOG.ERROR, err));
-
+                        .catch((err) => logger.error(LOG.ERROR, err));
             })
             .catch((err) => logger.error(LOG.ERROR, err));
     });

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const { getLocalDependencies } = require('./lib/local');
 const { LOG } = require('./lib/constants');
 const Resolver = require('./lib/resolver');
 
+const resolver = new Resolver();
+
 function init(repo, logger) {
     downloadRepo(repo)
         .then((arr) => arr.map((file) => `${LOG.SPACER} - ${file}`))
@@ -22,7 +24,7 @@ function init(repo, logger) {
 function initLocal(logger) {
     getLocalDependencies()
         .then((deps) => {
-            new Resolver()
+            resolver
                 .validate(deps)
                     .then(valid => valid.forEach(config => init(config.repoName, logger)))
                     .catch(err => logger.error(LOG.ERROR, err));
@@ -48,7 +50,7 @@ prog
     .action((args, options, logger) => {
         getLocalDependencies()
             .then((deps) => {
-                new Resolver(options)
+                resolver
                     .on('valid', (repo) => logger.info(LOG.VALID, repo.repoName))
                     .on('invalid', (repo) => logger.error(LOG.INVALID, repo.repoName))
                     .validate(deps)

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -22,6 +22,6 @@ module.exports = {
         TITLE: chalk.cyan.underline,
         VALID: chalk.green('Valid:'),
         INVALID: chalk.red('Invalid:'),
-    }
+    },
 };
 

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -4,6 +4,24 @@ const { ZEL } = require('./constants');
 const { bufferToJSON, get, sync } = require('./utils');
 
 /**
+ * Fetches the zel configuration file from the remote repository.
+ *
+ * @param {String} repoName - The repo name
+ * @return {Promise<Object>} - The configuration object
+ */
+const fetchZelFile = (repoName) => new Promise((resolve, reject) => {
+    get(`https://api.github.com/repos/${repoName}/contents/${ZEL.FILE}`)
+        .then((resp) => {
+            if (resp.message === 'Not Found') {
+                reject(`${repoName} not found.`);
+            }
+            const config = bufferToJSON(resp.content, `"${ZEL.FILE}" from ${repoName}`);
+            resolve(config);
+        })
+        .catch((err) => reject(err));
+});
+
+/**
  * Retrieve the zel configuration of the specified repository name.
  *
  * Config are cached into the `ZEL.CACHEDIR` directory
@@ -30,24 +48,6 @@ const getZelFile = (repoName) => new Promise((resolve, reject) => {
     const config = cache.get('config');
 
     resolve(config);
-});
-
-/**
- * Fetches the zel configuration file from the remote repository.
- *
- * @param {String} repoName - The repo name
- * @return {Promise<Object>} - The configuration object
- */
-const fetchZelFile = (repoName) => new Promise((resolve, reject) => {
-    get(`https://api.github.com/repos/${repoName}/contents/${ZEL.FILE}`)
-        .then((resp) => {
-            if (resp.message === 'Not Found') {
-                reject(`${repoName} not found.`);
-            }
-            const config = bufferToJSON(resp.content, `"${ZEL.FILE}" from ${repoName}`);
-            resolve(config);
-        })
-        .catch((err) => reject(err));
 });
 
 /**

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -51,48 +51,25 @@ const fetchZelFile = (repoName) => new Promise((resolve, reject) => {
 });
 
 /**
- * Downloads from a Github repo
- *
- * @param {String} repoName - The repo name
- * @return {Promise<String[]>} - The list of files that were downloaded
- */
-const downloadRepo = (repoName) => new Promise((resolve, reject) => {
-    const parts = repoName.split('/');
-    if (parts.length !== 2) {
-        reject('Invalid repository name. Format should be "<username>/<repository>"');
-    }
-
-    // fetches the dotfile to find the files to download
-    getZelFile(repoName)
-        .then((config) => {
-            const files = fetchFiles(repoName, config.files);
-            // @TODO read remote dependencies
-            resolve(files);
-        })
-        .catch((err) => reject(err));
-});
-
-/**
  * Fetch the list of files in the given repository, and creates them
  * in the current directory.
  *
- * @param {String} repoName - The full repo name (username/repository)
- * @param {Array<String>} files - A list of files
- * @return {Array<String>} - The files downloaded
+ * @parma {String} - The repository name
+ * @param {Object} - The zel config object
+ * @return {Object} - An object with the repository name and config
  */
-const fetchFiles = (repoName, files) => {
-    if (!files) {
+const fetchFiles = (repoName, config) => {
+    if (!config.files) {
         throw `No files specified in ${repoName}.`;
     }
 
     // @TODO - parse tag or branch name from `dependencies`
-    files.forEach((file) => sync(repoName, 'master', file));
+    config.files.forEach((file) => sync(repoName, 'master', file));
 
-    return files;
+    return { repoName, config };
 };
 
 module.exports = {
     getZelFile,
-    downloadRepo,
     fetchFiles,
 };

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -7,7 +7,6 @@ module.exports = class Resolver extends EventEmitter {
         this.valid = [];
         this.invalid = [];
         this.opts = options || {};
-        this.fetch = this.fetch.bind(this);
     }
 
     /**
@@ -28,7 +27,7 @@ module.exports = class Resolver extends EventEmitter {
             return Promise.reject('No repositories specified.');
         }
 
-        return Promise.all(repos.map(this.fetch))
+        return Promise.all(repos.map(this.fetch, this))
             .then(() => this.valid.forEach(config => this.emit('valid', config)))
             .then(() => this.invalid.forEach(config => this.emit('invalid', config)))
             .then(() => (repos.length === this.valid.length && this.valid) || Promise.reject(this.invalid))

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -28,8 +28,8 @@ module.exports = class Resolver extends EventEmitter {
         }
 
         return Promise.all(repos.map(this.fetch, this))
-            .then(() => this.valid.forEach(config => this.emit('valid', config)))
-            .then(() => this.invalid.forEach(config => this.emit('invalid', config)))
+            .then(() => this.valid.forEach((config) => this.emit('valid', config)))
+            .then(() => this.invalid.forEach((config) => this.emit('invalid', config)))
             .then(() => (repos.length === this.valid.length && this.valid) || Promise.reject(this.invalid))
             .catch((err) => err);
     }
@@ -43,6 +43,6 @@ module.exports = class Resolver extends EventEmitter {
     fetch(repoName) {
         return getZelFile(repoName)
             .then((config) => this.valid.push({ repoName, config }) && config)
-            .catch(err => this.invalid.push({ repoName, config: null }));
+            .catch(() => this.invalid.push({ repoName, config: null }));
     }
 };

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -2,41 +2,48 @@ const EventEmitter = require('events');
 const { getZelFile } = require('./repository');
 
 module.exports = class Resolver extends EventEmitter {
-    /**
-     * @param {Object<failFast>} failFast - Terminates if an error/invalid event occurs
-     */
     constructor(options) {
         super();
+        this.valid = [];
+        this.invalid = [];
         this.opts = options || {};
+        this.fetch = this.fetch.bind(this);
     }
 
     /**
-     * Validates the repositories
+     * Validates all repositores.
+     *
+     * If all specified repositories are valid, returns a resolved
+     * Promise that resolves a list of config objects for each
+     * repository.
+     *
+     * If any repository is invalid, returns a rejected Promise
+     * of the list of invalid repositories.
      *
      * @param {Array<String>} - List of repositories
+     * @return {Promise<Array<Object>>} - Resolves a list of valid/invalid config objects
      */
     validate(repos) {
-        const failFast = this.opts.failFast;
-
         if (!repos || !repos.length) {
-            this.emit('error', 'No repositories specified.');
-            if (failFast) {
-                return false;
-            }
+            return Promise.reject('No repositories specified.');
         }
 
-        if (failFast) {
-            const isValid = (name) => this.emit('valid', name);
-            Promise.each(repos, getZelFile)
-                .then((repoNames) => repoNames.forEach(isValid))
-                .catch((repoName) => this.emit('invalid', repoName));
-            return;
-        }
+        return Promise.all(repos.map(this.fetch))
+            .then(() => this.valid.forEach(config => this.emit('valid', config)))
+            .then(() => this.invalid.forEach(config => this.emit('invalid', config)))
+            .then(() => (repos.length === this.valid.length && this.valid) || Promise.reject(this.invalid))
+            .catch((err) => err);
+    }
 
-        const check = (repoName) => getZelFile(repoName)
-            .then(() => this.emit('valid', repoName))
-            .catch(() => this.emit('invalid', repoName));
-
-        Promise.all(repos.map(check));
+    /**
+     * Fetch the repository and store to approriate list
+     *
+     * @param {String} repoName - The repository name
+     * @return {Promise{Object}> - Resolves the zel config object
+     */
+    fetch(repoName) {
+        return getZelFile(repoName)
+            .then((config) => this.valid.push({ repoName, config }) && config)
+            .catch(err => this.invalid.push({ repoName, config: null }));
     }
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "zel": "./index.js"
   },
   "scripts": {
-    "lint": "eslint index.js utils",
+    "lint": "eslint index.js lib",
     "test": "npm run lint"
   },
   "keywords": [],


### PR DESCRIPTION
- `Resolver.validate()` should now return a Promise that resolves a list of valid or invalid config objects. (for future use)
- Remove the need for an `error` event in the `Resolver`
- Removes `failFast` and validates all by default (#16)
- Moved `check()` to `Resolver.fetch()` (easier for writing tests later)