### PR TITLE
follow remote dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,13 +12,15 @@ const resolver = new Resolver();
 
 function writeLog(entries, logger) {
     entries.forEach((entry) => {
-        const str = entry.config.files
-            .map((file) => `${LOG.SPACER} - ${file}`)
-            .concat('')
-            .join('\n');
+        if (entry.config.files) {
+            const str = entry.config.files
+                .map((file) => `${LOG.SPACER} - ${file}`)
+                .concat('')
+                .join('\n');
 
-        logger.info(LOG.DOWNLOADED, LOG.TITLE(entry.repoName));
-        logger.info(str);
+            logger.info(LOG.DOWNLOADED, LOG.TITLE(entry.repoName));
+            logger.info(str);
+        }
     });
 }
 

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -51,20 +51,17 @@ const getZelFile = (repoName) => new Promise((resolve, reject) => {
 });
 
 /**
- * Fetch the list of files in the given repository, and creates them
- * in the current directory.
+ * Fetch the list of files in the given repository,
+ * and creates them in the current directory.
  *
  * @parma {String} - The repository name
  * @param {Object} - The zel config object
  * @return {Object} - An object with the repository name and config
  */
 const fetchFiles = (repoName, config) => {
-    if (!config.files) {
-        throw `No files specified in ${repoName}.`;
+    if (config.files && config.files.length) {
+        config.files.forEach((file) => sync(repoName, 'master', file));
     }
-
-    // @TODO - parse tag or branch name from `dependencies`
-    config.files.forEach((file) => sync(repoName, 'master', file));
 
     return { repoName, config };
 };

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -39,11 +39,25 @@ module.exports = class Resolver extends EventEmitter {
      * Fetch the repository and store to approriate list
      *
      * @param {String} repoName - The repository name
-     * @return {Promise{Object}> - Resolves the zel config object
+     * @return {Promise<Object>} - Resolves the zel config object
      */
     fetch(repoName) {
         return getZelFile(repoName)
             .then((config) => this.valid.push({ repoName, config }) && config)
+            .then((config) => this.fetchDependencies(config))
             .catch(() => this.invalid.push({ repoName, config: null }));
+    }
+
+    /**
+     * Fetch dependencies
+     *
+     * @param {Object} config - The zel config object
+     * @return {Promise<Array<Object>>} - Resolves a list of zel config objects
+     */
+    fetchDependencies(config) {
+        if (config.dependencies && config.dependencies.length) {
+            return Promise.all(config.dependencies.map(this.fetch, this));
+        }
+        return [config];
     }
 };


### PR DESCRIPTION
Updated the `Resolver` to follow dependencies (Addresses #3)

Demo: [vutran/new2](https://github.com/vutran/new2)

```bash
$ zel vutran/new2
```