### PR TITLE
hotfix - validity check

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -30,8 +30,8 @@ module.exports = class Resolver extends EventEmitter {
         return Promise.all(repos.map(this.fetch, this))
             .then(() => this.valid.forEach((config) => this.emit('valid', config)))
             .then(() => this.invalid.forEach((config) => this.emit('invalid', config)))
-            .then(() => repos.length === this.valid.length)
-            .then((isValid) => this.valid || Promise.reject(this.invalid))
+            .then(() => repos.length <= this.valid.length)
+            .then((isValid) => isValid ? this.valid : Promise.reject(this.invalid))
             .catch((err) => err);
     }
 


### PR DESCRIPTION
Missed this during a rebase earlier.

Should resolve `valid` only if resolved list has same or more entries.