### PR TITLE
throw error if file not found

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,8 +100,14 @@ const getConfig = file =>
  */
 const sync = (repo, branch, file) => {
     const uri = `https://raw.githubusercontent.com/${repo}/${branch}/${file}`;
-    const fileStream = fs.createWriteStream(file);
-    https.get(uri, resp => resp.pipe(fileStream));
+    https.get(uri, resp => {
+        if (resp.statusCode === 200) {
+            const fileStream = fs.createWriteStream(file);
+            resp.pipe(fileStream);
+        } else {
+            throw `404: Error trying to retrieve ${repo}/${branch}/${file}.`;
+        }
+    });
 };
 
 module.exports = {


### PR DESCRIPTION
Quick fix for #29.

Ideally, we would want to start building the file resolvers before logging/writing to disk.