### PR TITLE
Write files with Ancestor Directories

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,11 @@
 const fs = require('fs');
 const url = require('url');
+const path = require('path');
 const https = require('https');
+const mkdir = require('mkdirp');
 const { name } = require('../package');
+
+const mkdirp = Promise.promisify(mkdir);
 
 /**
  * Parse a (`.zel`) file's base64 string as JSON.
@@ -103,6 +107,12 @@ const sync = (repo, branch, file) => {
     const fileStream = fs.createWriteStream(file);
     https.get(uri, resp => resp.pipe(fileStream));
 };
+
+const write = Promise.method((file, data, opts) => {
+    file = path.normalize(file);
+    const dirs = path.dirname(file);
+    return mkdirp(dirs).then(() => write(file, data, opts));
+});
 
 module.exports = {
     bufferToJSON,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ const mkdir = require('mkdirp');
 const { name } = require('../package');
 
 const mkdirp = Promise.promisify(mkdir);
+const writeFile = Promise.promisify(fs.writeFile);
 
 /**
  * Parse a (`.zel`) file's base64 string as JSON.
@@ -96,6 +97,20 @@ const getConfig = file =>
     });
 
 /**
+ * Write to a file with given data.
+ * Creates ancestor directories if needed.
+ *
+ * @param {String} file - The full file"s path.
+ * @param {String} data - The data to write.
+ * @param {Object} opts - See `fs.writeFile`.
+ */
+const write = Promise.method((file, data, opts) => {
+    file = path.normalize(file);
+    const dirs = path.dirname(file);
+    return mkdirp(dirs).then(() => writeFile(file, data, opts));
+});
+
+/**
  * Downloads the contents from the given repo file path components.
  *
  * @param {String} repo
@@ -104,15 +119,14 @@ const getConfig = file =>
  */
 const sync = (repo, branch, file) => {
     const uri = `https://raw.githubusercontent.com/${repo}/${branch}/${file}`;
-    const fileStream = fs.createWriteStream(file);
-    https.get(uri, resp => resp.pipe(fileStream));
+    https.get(uri, resp => {
+        let data = '';
+        resp.on('data', d => {
+            data += d;
+        });
+        resp.on('end', () => write(file, data));
+    });
 };
-
-const write = Promise.method((file, data, opts) => {
-    file = path.normalize(file);
-    const dirs = path.dirname(file);
-    return mkdirp(dirs).then(() => write(file, data, opts));
-});
 
 module.exports = {
     bufferToJSON,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "bluebird": "^3.5.0",
     "cache-conf": "^0.5.0",
     "caporal": "^0.3.0",
-    "chalk": "^1.1.3"
+    "chalk": "^1.1.3",
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "husky": "^0.13.2",


### PR DESCRIPTION
Uses `mkdirp` (promisifed) to create any missing directories. The package was already in use & installed via `cache-conf`.

The new `write` utility is a non-coroutine version of my util from Fly ([ref](https://github.com/flyjs/fly/blob/master/lib/utils/write.js)).

Closes #30 