### PR TITLE
Allow passing a token when validating/fetching configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "cache-conf": "^0.5.0",
-    "caporal": "^0.3.0",
+    "caporal": "^0.5.0",
     "chalk": "^1.1.3",
     "mkdirp": "^0.5.1"
   },

--- a/src/fetchers/base.js
+++ b/src/fetchers/base.js
@@ -4,7 +4,16 @@ import type { ZelConfig } from '../config';
 import EventEmitter from 'events';
 import Promise from 'bluebird';
 
+interface FetchOptions {
+    // add options here...
+}
+
 export default class BaseFetcher extends EventEmitter {
+    constructor(options: FetchOptions) {
+        super();
+        this.options = options;
+    }
+
     /**
      * Fetches a configuration file
      *

--- a/src/fetchers/github.js
+++ b/src/fetchers/github.js
@@ -8,6 +8,11 @@ import { ZEL } from '../constants';
 import { bufferToJSON, get } from '../utils';
 import BaseFetcher from './base';
 
+export interface FetchOptions {
+    // optional GitHub token
+    token?: string;
+}
+
 export default class GitHubFetcher extends BaseFetcher {
     /**
      * Retrieve the zel configuration file from the cache if available
@@ -27,11 +32,20 @@ export default class GitHubFetcher extends BaseFetcher {
     /**
      * Fetches the zel configuration file from the GitHub repository.
      *
+     * If a token is set, makes an authenticated request.
+     *
      * @param {string} repoName - The repo name
+     * @param {FetchOptions} options - Dictionary of fetch options
      * @return {Promise<ZelConfig>} - The configuration object
      */
-    fetchFromRemote(repoName: string): Promise<ZelConfig> {
-        return get(`https://api.github.com/repos/${repoName}/contents/${ZEL.FILE}`)
+    fetchFromRemote(repoName: string, options: FetchOptions): Promise<ZelConfig> {
+        const opts = { json: true };
+
+        if (options.token) {
+            opts.token = options.token;
+        }
+
+        return get(`https://api.github.com/repos/${repoName}/contents/${ZEL.FILE}`, opts)
             .then(resp => {
                 if (resp.message === 'Not Found') {
                     return Promise.reject(`${repoName} not found.`);
@@ -45,9 +59,10 @@ export default class GitHubFetcher extends BaseFetcher {
      * Fetches the zel configuration file from cache, or GitHub API
      *
      * @param {string} repoName - The repo name
+     * @param {FetchOptions} options - Dictionary of fetch options
      * @return {Promise<ZelConfig>} - The configuration object
      */
-    fetchConfig(repoName: string): Promise<ZelConfig> {
+    fetchConfig(repoName: string, options: FetchOptions): Promise<ZelConfig> {
         const cache = new CacheConf({
             configName: ZEL.FILE,
             cwd: path.join(ZEL.CACHEDIR, repoName),
@@ -59,7 +74,7 @@ export default class GitHubFetcher extends BaseFetcher {
             return Promise.resolve((config: ZelConfig));
         }
 
-        return this.fetchFromRemote(repoName)
+        return this.fetchFromRemote(repoName, options)
             .then(config => {
                 cache.set('config', config, { maxAge: ZEL.CACHETIMEOUT });
                 return Promise.resolve(config);

--- a/src/fetchers/github.js
+++ b/src/fetchers/github.js
@@ -14,6 +14,10 @@ export interface FetchOptions {
 }
 
 export default class GitHubFetcher extends BaseFetcher {
+    constructor(options: FetchOptions) {
+        super(options);
+    }
+
     /**
      * Retrieve the zel configuration file from the cache if available
      *
@@ -35,14 +39,13 @@ export default class GitHubFetcher extends BaseFetcher {
      * If a token is set, makes an authenticated request.
      *
      * @param {string} repoName - The repo name
-     * @param {FetchOptions} options - Dictionary of fetch options
      * @return {Promise<ZelConfig>} - The configuration object
      */
-    fetchFromRemote(repoName: string, options: FetchOptions): Promise<ZelConfig> {
+    fetchFromRemote(repoName: string): Promise<ZelConfig> {
         const opts = { json: true };
 
-        if (options.token) {
-            opts.token = options.token;
+        if (this.options.token) {
+            opts.token = this.options.token;
         }
 
         return get(`https://api.github.com/repos/${repoName}/contents/${ZEL.FILE}`, opts)
@@ -59,10 +62,9 @@ export default class GitHubFetcher extends BaseFetcher {
      * Fetches the zel configuration file from cache, or GitHub API
      *
      * @param {string} repoName - The repo name
-     * @param {FetchOptions} options - Dictionary of fetch options
      * @return {Promise<ZelConfig>} - The configuration object
      */
-    fetchConfig(repoName: string, options: FetchOptions): Promise<ZelConfig> {
+    fetchConfig(repoName: string): Promise<ZelConfig> {
         const cache = new CacheConf({
             configName: ZEL.FILE,
             cwd: path.join(ZEL.CACHEDIR, repoName),
@@ -74,7 +76,7 @@ export default class GitHubFetcher extends BaseFetcher {
             return Promise.resolve((config: ZelConfig));
         }
 
-        return this.fetchFromRemote(repoName, options)
+        return this.fetchFromRemote(repoName)
             .then(config => {
                 cache.set('config', config, { maxAge: ZEL.CACHETIMEOUT });
                 return Promise.resolve(config);

--- a/src/resolvers/base.js
+++ b/src/resolvers/base.js
@@ -9,6 +9,11 @@ export interface ResolvedZelConfig {
     config?: ZelConfig;
 }
 
+export interface ValidateOptions {
+    // optional GitHub token
+    token?: string;
+}
+
 export default class BaseResolver extends EventEmitter {
     valid: Array<ResolvedZelConfig>;
     invalid: Array<ResolvedZelConfig>;
@@ -28,9 +33,10 @@ export default class BaseResolver extends EventEmitter {
      * of the list of invalid item.
      *
      * @param {Array<string>} - List of inputs
+     * @param {ValidateOptions} - Dictionary of validation options
      * @return {Promise<Array<ResolvedZelConfig>>} - Resolves a list of resolved valid/invalid config objects
      */
-    validate(list: Array<string>): Promise<Array<ResolvedZelConfig>> {
+    validate(list: Array<string>, options: ValidateOptions): Promise<Array<ResolvedZelConfig>> {
         return Promise.reject('Not yet implemented.');
     }
 }

--- a/src/resolvers/base.js
+++ b/src/resolvers/base.js
@@ -9,21 +9,20 @@ export interface ResolvedZelConfig {
     config?: ZelConfig;
 }
 
-export interface ValidateOptions {
-    // optional GitHub token
-    token?: string;
+interface ValidateOptions {
+    // add options here...
 }
 
 export default class BaseResolver extends EventEmitter {
     valid: Array<ResolvedZelConfig>;
     invalid: Array<ResolvedZelConfig>;
-    opts: any;
+    options: ValidateOptions;
 
-    constructor(options: any) {
+    constructor(options: ValidateOptions) {
         super();
+        this.options = options || {};
         this.valid = [];
         this.invalid = [];
-        this.opts = options || {};
     }
 
     /**
@@ -33,10 +32,9 @@ export default class BaseResolver extends EventEmitter {
      * of the list of invalid item.
      *
      * @param {Array<string>} - List of inputs
-     * @param {ValidateOptions} - Dictionary of validation options
      * @return {Promise<Array<ResolvedZelConfig>>} - Resolves a list of resolved valid/invalid config objects
      */
-    validate(list: Array<string>, options: ValidateOptions): Promise<Array<ResolvedZelConfig>> {
+    validate(list: Array<string>): Promise<Array<ResolvedZelConfig>> {
         return Promise.reject('Not yet implemented.');
     }
 }

--- a/src/resolvers/github.js
+++ b/src/resolvers/github.js
@@ -1,14 +1,27 @@
 // @flow
 
 import type { ZelConfig } from '../config';
-import type { ResolvedZelConfig, ValidateOptions } from './base';
+import type { ResolvedZelConfig } from './base';
 import Promise from 'bluebird';
 import BaseResolver from './base';
 import GitHubFetcher from '../fetchers/github';
 
-const fetcher = new GitHubFetcher();
+interface ValidateOptions {
+    // optional GitHub token
+    token?: string;
+}
 
 export default class GithubResolver extends BaseResolver {
+    constructor(options: ValidateOptions) {
+        super(options);
+
+        const fetcherOptions = {
+            token: (options && options.token) || null,
+        };
+
+        this.fetcher = new GitHubFetcher(fetcherOptions);
+    }
+
     /**
      * Validates the given list of repositories.
      *
@@ -20,15 +33,14 @@ export default class GithubResolver extends BaseResolver {
      * of the list of invalid repositories.
      *
      * @param {Array<string>} - List of repositories
-     * @param {ValidateOptions} - Dictionary of validation options
      * @return {Promise<Array<ResolvedZelConfig>>} - Resolves a list of valid/invalid config objects
      */
-    validate(repos: Array<string>, options: ValidateOptions): Promise<Array<ResolvedZelConfig>> {
+    validate(repos: Array<string>): Promise<Array<ResolvedZelConfig>> {
         if (!repos || !repos.length) {
             return Promise.reject('No repositories specified.');
         }
 
-        return Promise.all(repos.map(repo => this.fetch(repo, options), this))
+        return Promise.all(repos.map(this.fetch, this))
             .then(() => this.valid.forEach(config => this.emit('valid', config)))
             .then(() => this.invalid.forEach(config => this.emit('invalid', config)))
             .then(() => repos.length <= this.valid.length)
@@ -40,13 +52,12 @@ export default class GithubResolver extends BaseResolver {
      * Fetch the repository and store to approriate list
      *
      * @param {string} repoName - The repository name
-     * @param {FetchOptions} options - Dictionary of fetch options
      * @return {Promise<ZelConfig>} - Resolves the zel config object
      */
-    fetch(repoName: string, options: FetchOptions): Promise<Array<ZelConfig>> {
-        return fetcher.fetchConfig(repoName, options)
+    fetch(repoName: string): Promise<Array<ZelConfig>> {
+        return this.fetcher.fetchConfig(repoName)
             .then(config => this.valid.push({ repoName, config }) && config)
-            .then(config => this.fetchDependencies(config, options))
+            .then(config => this.fetchDependencies(config))
             .catch(err => {
                 this.invalid.push({ repoName });
                 Promise.reject(err);
@@ -57,12 +68,11 @@ export default class GithubResolver extends BaseResolver {
      * Fetch dependencies
      *
      * @param {ZelConfig} config - The zel config object
-     * @param {FetchOptions} options - Dictionary of fetch options
      * @return {Array<ZelConfig>|Promise<Array<ZelConfig>>} - Resolves a list of zel config objects
      */
-    fetchDependencies(config: ZelConfig, options: FetchOptions): Array<ZelConfig> | Promise<Array<ZelConfig>> {
+    fetchDependencies(config: ZelConfig): Array<ZelConfig> | Promise<Array<ZelConfig>> {
         if (config.dependencies && config.dependencies.length) {
-            return Promise.all(config.dependencies.map(dep => this.fetch(dep, options), this));
+            return Promise.all(config.dependencies.map(this.fetch, this));
         }
         return [config];
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -619,16 +619,16 @@ camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
-caporal@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/caporal/-/caporal-0.3.0.tgz#bb8b56857244251c3298db9d1524fd2254989c84"
+caporal@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/caporal/-/caporal-0.5.0.tgz#f787ac86cd5523478eb4213b480422a39e0229fe"
   dependencies:
     bluebird "^3.4.7"
     chalk "^1.1.3"
     cli-table2 "^0.2.0"
     fast-levenshtein "^2.0.6"
     lodash.camelcase "^4.3.0"
-    minimist "^1.2.0"
+    micromist "^1.0.1"
     prettyjson "^1.2.1"
     tabtab "^2.2.2"
     winston "^2.3.1"
@@ -1470,6 +1470,12 @@ micromatch@^2.1.5:
     object.omit "^2.0.0"
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
+
+micromist@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/micromist/-/micromist-1.0.2.tgz#41f84949a04c30cdc60a394d0cb06aaa08b86364"
+  dependencies:
+    lodash.camelcase "^4.3.0"
 
 mime-db@~1.27.0:
   version "1.27.0"


### PR DESCRIPTION
This PR adds a new `--token <token>` option which gets passed to the resolver to make an authenticated request to fetch the zel config file.

I've also merged the call to `http.get()` in `sync()` to reuse the existing `get()` helper method.