### PR TITLE
Move types directory

### DIFF
--- a/flyfile.js
+++ b/flyfile.js
@@ -1,4 +1,5 @@
 const tests = '__tests__/*.js';
+const types = 'src/types/**';
 const src = 'src/**/*.js';
 const dist = 'lib';
 
@@ -7,7 +8,7 @@ export async function clean(fly) {
 }
 
 export async function build(fly, opts) {
-    await fly.source(opts.src || src).unflow().target(dist);
+    await fly.source(opts.src || src, { ignore:types }).unflow().target(dist);
 }
 
 export async function lint(fly) {

--- a/flyfile.js
+++ b/flyfile.js
@@ -1,5 +1,4 @@
 const tests = '__tests__/*.js';
-const mocks = '__mocks__/*.js';
 const src = 'src/**/*.js';
 const dist = 'lib';
 
@@ -26,6 +25,6 @@ export async function test(fly) {
 }
 
 export async function watch(fly) {
+    await fly.watch([tests, '__mocks__/*.js'], 'test');
     await fly.watch(src, ['build', 'test']);
-    await fly.watch([tests, mocks], 'test');
 }

--- a/src/fetchers/base.js
+++ b/src/fetchers/base.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ZelConfig, FetchOptions } from '../../types';
+import type { ZelConfig, FetchOptions } from '../types';
 const EventEmitter = require('events');
 const Promise = require('bluebird');
 

--- a/src/fetchers/file.js
+++ b/src/fetchers/file.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ZelConfig } from '../../types';
+import type { ZelConfig } from '../types';
 const BaseFetcher = require('./base');
 
 class FileFetcher extends BaseFetcher {

--- a/src/fetchers/github.js
+++ b/src/fetchers/github.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ZelConfig, FetchOptions } from '../../types';
+import type { ZelConfig, FetchOptions } from '../types';
 const path = require('path');
 const Promise = require('bluebird');
 const CacheConf = require('cache-conf');

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // @flow
-import type { ZelConfig } from '../types';
+import type { ZelConfig } from './types';
 const prog = require('caporal');
 const Promise = require('bluebird');
 const { version } = require('../package');

--- a/src/resolvers/base.js
+++ b/src/resolvers/base.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ZelConfig, ValidateOptions } from '../../types';
+import type { ZelConfig, ValidateOptions } from '../types';
 const EventEmitter = require('events');
 const Promise = require('bluebird');
 

--- a/src/resolvers/github.js
+++ b/src/resolvers/github.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ZelConfig, ResolvedZelConfig, ValidateOptions } from '../../types';
+import type { ZelConfig, ResolvedZelConfig, ValidateOptions } from '../types';
 const Promise = require('bluebird');
 const BaseResolver = require('./base');
 const GitHubFetcher = require('../fetchers/github');

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -7,14 +7,14 @@ export interface ZelConfig {
 }
 
 export interface ResolvedZelConfig {
-    repoName: string;
-    config?: ZelConfig;
+    repoName: string,
+    config?: ZelConfig,
 }
 
 export interface FetchOptions {
-    token?: string;
+    token?: string,
 }
 
 export interface ValidateOptions {
-    token?: string;
+    token?: string,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 // @flow
-import type { ZelConfig } from '../types';
+import type { ZelConfig } from './types';
 const { dirname, normalize } = require('path');
 const { readFile, writeFile } = require('fs');
 const Promise = require('bluebird');


### PR DESCRIPTION
It makes more sense to me to have these be within `src` since they're only used within development contexts. Doing it like this also allows it be processed by `prettier`. 

Modified the `build` task to ignore types & the `watch` task will re-run on `__{tests,mocks}__` changes.