### PR TITLE
add contrib section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ For more information
 $ zel -h
 ```
 
+## Contributing
+
+1. Clone the repository: `git clone git@github.com:vutran/zel.git`
+2. Install dependencies: `npm install` or `yarn`
+3. Install [flow-typed](https://github.com/flowtype/flow-typed) typings: `npm run flow-typed`
+4. Start [Fly](https://github.com/flyjs/fly) dev task: `npm run dev`
+5. Make edits, commit
+6. Submit a [PR](https://github.com/vutran/zel/compare).
+
 ## License
 
 MIT © [Vu Tran](https://github.com/vutran/)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "fly clean build",
     "dev": "fly watch",
     "flow": "flow",
-    "postinstall": "flow-typed install",
+    "flow-typed": "flow-typed install",
     "precommit": "fly lint",
     "prepublish": "npm run build",
     "test": "fly build test"


### PR DESCRIPTION
Separates the `flow-typed install` script into it's own npm script and adds a contributing section that documents it. Allows us to keep the `flow-typed` directory clean/ignored.