### PR TITLE
Add `--help` text

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,23 @@ const repo = flags._[0];
 const dest = path.resolve((flags.home && home) || flags._[1] || '.');
 
 if (flags.help || !repo) {
-	return console.log('show help');
+	const _ = chalk.underline;
+	return console.log(`
+  ${_('Usage')}
+    $ zel <repo> [target]
+
+  ${_('Options')}
+    --cache -c    Disable HTTP requests; offline mode.
+    --force -f    Prefer to download a new archive.
+     --help -h    Display this help message.
+
+  ${_('Examples')}
+    $ zel vutran/boiler
+    $ zel vutran/boiler my-app
+    $ zel vutran/boiler#v1.2.0
+    $ zel gitlab:vutran/boiler
+    $ zel vutran/boiler --cache
+	`);
 }
 
 const log = msg => console.log(chalk.magenta('> ') + msg);


### PR DESCRIPTION
Also shows when the `target` directory is missing.

Fairly standard format/structure.